### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/Driver/Fuse/FuseService.cpp
+++ b/src/Driver/Fuse/FuseService.cpp
@@ -230,7 +230,7 @@ namespace VeraCrypt
 						FuseService::ReadVolumeSectors (BufferPtr ((byte *) buf, size), offset);
 					}
 				}
-				catch (MissingVolumeData)
+				catch (MissingVolumeData&)
 				{
 					return 0;
 				}
@@ -359,7 +359,7 @@ namespace VeraCrypt
 		{
 			throw;
 		}
-		catch (std::bad_alloc)
+		catch (std::bad_alloc&)
 		{
 			return -ENOMEM;
 		}


### PR DESCRIPTION
Fixing the following compiler warnings:

```
FuseService.cpp: In function ‘int VeraCrypt::fuse_service_read(const char*, char*, size_t, off_t, fuse_file_info*)’: FuseService.cpp:233:12: warning: catching polymorphic type ‘struct VeraCrypt::MissingVolumeData’ by value [-Wcatch-value=]
  233 |     catch (MissingVolumeData)
      |            ^~~~~~~~~~~~~~~~~
FuseService.cpp: In static member function ‘static int VeraCrypt::FuseService::ExceptionToErrorCode()’:
FuseService.cpp:362:15: warning: catching polymorphic type ‘class std::bad_alloc’ by value [-Wcatch-value=]
  362 |   catch (std::bad_alloc)
      |               ^~~~~~~~~

```
Apart from warnings, the current code creates unnecessary copies of the exception object in debug mode. (But not in -O3)